### PR TITLE
moved the part where the user agent is set to constructRequest function

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -118,11 +118,6 @@ func (b *Bot) Subscribe(streams []string) (*http.Response, error) {
 	body := "subscriptions=" + string(bodyBts)
 
 	req, err := b.constructRequest("POST", "users/me/subscriptions", body)
-	if b.UserAgent != "" {
-		req.Header.Set("User-Agent", b.UserAgent)
-	} else {
-		req.Header.Set("User-Agent", fmt.Sprintf("gozulipbot/%s", Release))
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -267,6 +262,12 @@ func (b *Bot) constructRequest(method, endpoint, body string) (*http.Request, er
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth(b.Email, b.APIKey)
+
+	if b.UserAgent != "" {
+		req.Header.Set("User-Agent", b.UserAgent)
+	} else {
+		req.Header.Set("User-Agent", fmt.Sprintf("gozulipbot/%s", Release))
+	}
 
 	return req, nil
 }


### PR DESCRIPTION
I'm not a Go programmer and I don't have the environment to test this, but from my understanding of the code and the fact that I see on my zulip server that matterbridge is only setting the user-agent on subscription requests, I moved the user-agent part into the `constructRequest` function. Then the user-agent should be correctly set on every request to zulip.

I hope my assumption is correct :)